### PR TITLE
Update openstack_hosts_configure_dnf.yml

### DIFF
--- a/tasks/openstack_hosts_configure_dnf.yml
+++ b/tasks/openstack_hosts_configure_dnf.yml
@@ -102,7 +102,7 @@
     - (install_method | default('source')) == 'distro'
 
 - name: Enable PowerTools repository
-  command: dnf config-manager --set-enabled PowerTools
+  command: dnf config-manager --set-enabled powertools
   changed_when: false
   when:
     - openstack_hosts_power_tool_enable | bool


### PR DESCRIPTION
I'm having a lot of issues with openstack-ansible and one of them is installing the PowerTools repo inside a container. It seems that running dnf repolist --all show the PowerTools repo to be named lowercase, like "powertools".  Please have a look.